### PR TITLE
display ability modifier; changed ability display order

### DIFF
--- a/characters/models.py
+++ b/characters/models.py
@@ -2,6 +2,11 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from math import floor
+
+
+def score_to_mod_string(score):
+    return "{:+d}".format(floor((score - 10) / 2))
 
 
 class Character(models.Model):
@@ -50,6 +55,30 @@ class Character(models.Model):
     speed = models.CharField(max_length=255, default='', blank=True)
     saving_throws = models.CharField(max_length=255, default='', blank=True)
     skills = models.CharField(max_length=255, default='', blank=True)
+
+    @property
+    def strength_mod(self):
+        return score_to_mod_string(self.strength)
+
+    @property
+    def dexterity_mod(self):
+        return score_to_mod_string(self.dexterity)
+
+    @property
+    def constitution_mod(self):
+        return score_to_mod_string(self.constitution)
+
+    @property
+    def intelligence_mod(self):
+        return score_to_mod_string(self.intelligence)
+
+    @property
+    def wisdom_mod(self):
+        return score_to_mod_string(self.wisdom)
+
+    @property
+    def charisma_mod(self):
+        return score_to_mod_string(self.charisma)
 
     class Meta:
         abstract = True

--- a/characters/templates/characters/monster_detail.html
+++ b/characters/templates/characters/monster_detail.html
@@ -74,7 +74,7 @@
                     <p>STR</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_monster.strength }}</p>
+                    <p>{{ this_monster.strength }} ({{ this_monster.strength_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -82,7 +82,7 @@
                     <p>DEX</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_monster.dexterity }}</p>
+                    <p>{{ this_monster.dexterity }} ({{ this_monster.dexterity_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -90,15 +90,7 @@
                     <p>CON</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_monster.constitution }}</p>
-                </div>
-            </div>
-            <div class="col-md-2">
-                <div class="character-label">
-                    <p>WIS</p>
-                </div>
-                <div class="character-details">
-                    <p>{{ this_monster.wisdom }}</p>
+                    <p>{{ this_monster.constitution }} ({{ this_monster.constitution_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -106,7 +98,15 @@
                     <p>INT</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_monster.intelligence }}</p>
+                    <p>{{ this_monster.intelligence }} ({{ this_monster.intelligence_mod }})</p>
+                </div>
+            </div>
+            <div class="col-md-2">
+                <div class="character-label">
+                    <p>WIS</p>
+                </div>
+                <div class="character-details">
+                    <p>{{ this_monster.wisdom }} ({{ this_monster.wisdom_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -114,7 +114,7 @@
                     <p>CHA</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_monster.charisma }}</p>
+                    <p>{{ this_monster.charisma }} ({{ this_monster.charisma_mod }})</p>
                 </div>
             </div>
         </div>

--- a/characters/templates/characters/npc_detail.html
+++ b/characters/templates/characters/npc_detail.html
@@ -74,7 +74,7 @@
                     <p>STR</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_npc.strength }}</p>
+                    <p>{{ this_npc.strength }} ({{ this_npc.strength_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -82,7 +82,7 @@
                     <p>DEX</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_npc.dexterity }}</p>
+                    <p>{{ this_npc.dexterity }} ({{ this_npc.dexterity_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -90,15 +90,7 @@
                     <p>CON</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_npc.constitution }}</p>
-                </div>
-            </div>
-            <div class="col-md-2">
-                <div class="character-label">
-                    <p>WIS</p>
-                </div>
-                <div class="character-details">
-                    <p>{{ this_npc.wisdom }}</p>
+                    <p>{{ this_npc.constitution }} ({{ this_npc.constitution_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -106,7 +98,15 @@
                     <p>INT</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_npc.intelligence }}</p>
+                    <p>{{ this_npc.intelligence }} ({{ this_npc.intelligence_mod }})</p>
+                </div>
+            </div>
+            <div class="col-md-2">
+                <div class="character-label">
+                    <p>WIS</p>
+                </div>
+                <div class="character-details">
+                    <p>{{ this_npc.wisdom }} ({{ this_npc.wisdom_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -114,7 +114,7 @@
                     <p>CHA</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_npc.charisma }}</p>
+                    <p>{{ this_npc.charisma }} ({{ this_npc.charisma_mod }})</p>
                 </div>
             </div>
         </div>

--- a/characters/templates/characters/player_detail.html
+++ b/characters/templates/characters/player_detail.html
@@ -75,7 +75,7 @@
                     <p>STR</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_player.strength }}</p>
+                    <p>{{ this_player.strength }} ({{ this_player.strength_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -83,7 +83,7 @@
                     <p>DEX</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_player.dexterity }}</p>
+                    <p>{{ this_player.dexterity }} ({{ this_player.dexterity_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -91,15 +91,7 @@
                     <p>CON</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_player.constitution }}</p>
-                </div>
-            </div>
-            <div class="col-md-2">
-                <div class="character-label">
-                    <p>WIS</p>
-                </div>
-                <div class="character-details">
-                    <p>{{ this_player.wisdom }}</p>
+                    <p>{{ this_player.constitution }} ({{ this_player.constitution_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -107,7 +99,15 @@
                     <p>INT</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_player.intelligence }}</p>
+                    <p>{{ this_player.intelligence }} ({{ this_player.intelligence_mod }})</p>
+                </div>
+            </div>
+            <div class="col-md-2">
+                <div class="character-label">
+                    <p>WIS</p>
+                </div>
+                <div class="character-details">
+                    <p>{{ this_player.wisdom }} ({{ this_player.wisdom_mod }})</p>
                 </div>
             </div>
             <div class="col-md-2">
@@ -115,7 +115,7 @@
                     <p>CHA</p>
                 </div>
                 <div class="character-details">
-                    <p>{{ this_player.charisma }}</p>
+                    <p>{{ this_player.charisma }} ({{ this_player.charisma_mod }})</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Effect:**
- The  stat block for Players, Monsters and NPCs now shows the ability modifier in parentheses after the ability score.
- The order of the displayed abilities is changed to the canonical order used in WotC publications: STR, DEX, CON, INT, WIS, CHA.

**Notes:**
- The conversion function from ability score to ability modifier string is a freestanding function; depending on your take on object oriented design, this could be a class method.
- The ability modifiers are implemented as read only properties in the model, so there is neither an entry field for the user, nor extra data in the database.